### PR TITLE
Auto-extract title and author from uploaded PDFs

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Install nbconvert toolchain
       run: |
         python -m pip install --upgrade pip
-        pip install nbconvert==7.* nbformat==5.* jinja2==3.* pygments==2.* pandocfilters
+        pip install nbconvert==7.* nbformat==5.* jinja2==3.* pygments==2.* pandocfilters pypdf==4.*
 
     - name: Convert .ipynb to HTML
       run: |
@@ -98,6 +98,7 @@ jobs:
         from datetime import datetime, timezone
         from pathlib import Path
         import nbformat
+        from pypdf import PdfReader
 
         REPO = Path(".").resolve()
         MEMOS_DIR = REPO / "memos"
@@ -152,6 +153,25 @@ jobs:
             print(f"Warning: couldn't parse {tex_path}: {e}")
           
           return metadata
+
+        def parse_pdf_metadata(pdf_path: Path):
+          """Extract title and authors from PDF document metadata."""
+          meta = {}
+          try:
+            reader = PdfReader(str(pdf_path))
+            info = reader.metadata
+            if info:
+              if info.title and info.title.strip():
+                meta["title"] = info.title.strip()
+              if info.author and info.author.strip():
+                raw = info.author.strip()
+                meta["authors"] = [a.strip() for a in re.split(r'[;,]|\sand\s', raw) if a.strip()]
+              if info.subject and info.subject.strip():
+                meta["summary"] = info.subject.strip()
+              print(f"PDF metadata for {pdf_path.name}: title={meta.get('title')}, authors={meta.get('authors')}")
+          except Exception as e:
+            print(f"Warning: couldn't read PDF metadata from {pdf_path}: {e}")
+          return meta
 
         def first_markdown_h1(nb):
           for cell in nb.cells:
@@ -275,7 +295,7 @@ jobs:
               memo_number = None
               print(f"New upload {slug} with first commit: {first_commit}")
 
-            # Read optional JSON sidecar for metadata
+            # Read metadata: JSON sidecar > PDF metadata > filename fallback
             sidecar = pdf.with_suffix(".json")
             meta = {}
             if sidecar.exists():
@@ -283,6 +303,9 @@ jobs:
                 meta = json.loads(sidecar.read_text(encoding="utf-8"))
               except Exception as e:
                 print(f"Warning: couldn't parse {sidecar}: {e}")
+
+            if not meta:
+              meta = parse_pdf_metadata(pdf)
 
             current_items.append({
               "slug": slug,

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For latex memos, replace the relevant metadata in the comments at the top of the
    git push
    ```
 
-   To add metadata for an uploaded PDF, create a JSON sidecar with the same name:
+   Title and author are automatically extracted from the PDF metadata (standard for LaTeX-compiled PDFs using `hyperref`). To override or add tags, create a JSON sidecar with the same name:
    ```bash
    cat > uploads/your-report.json <<EOF
    {
@@ -76,7 +76,7 @@ For latex memos, replace the relevant metadata in the comments at the top of the
    git commit -m "add metadata for your-report"
    git push
    ```
-   If no JSON sidecar is provided, the filename is used as the title.
+   The JSON sidecar takes priority over PDF metadata. If neither is available, the filename is used as the title.
    
 
 6. **Create a pull request**  


### PR DESCRIPTION
## Summary
- Uses `pypdf` to read PDF document metadata (title, author, subject) for uploaded PDFs in `uploads/`
- No JSON sidecar needed for standard LaTeX-compiled PDFs that embed metadata via `hyperref`
- Priority: JSON sidecar > PDF metadata > filename fallback
- Updated README to document the auto-extraction behavior

cc @AaronParsons

## Test plan
- [ ] Upload a LaTeX-compiled PDF with `\title` and `\author` set — verify title and author appear on the site without a JSON sidecar
- [ ] Upload a PDF with a JSON sidecar — verify sidecar values take priority
- [ ] Upload a PDF with no metadata and no sidecar — verify filename is used as title

🤖 Generated with [Claude Code](https://claude.com/claude-code)