### PR TITLE
release: pin Software-tab links to eigsep-field v2026.7.1

### DIFF
--- a/docs/_data/eigsep_field.yml
+++ b/docs/_data/eigsep_field.yml
@@ -3,5 +3,5 @@
 # new release tag (e.g. v2026.5.0). Between releases, tracking main is
 # acceptable because eigsep-field's docs-drift CI keeps interface docs
 # honest on every commit.
-tag: main
+tag: v2026.7.1
 repo_url: https://github.com/EIGSEP/eigsep-field


### PR DESCRIPTION
Release-coordination checklist step for eigsep-field **2026.7.1**: flip
`docs/_data/eigsep_field.yml :: tag` from `main` to the release tag so
every outbound Software-tab link pins to the blessed tuple.

Release: https://github.com/EIGSEP/eigsep-field/releases/tag/v2026.7.1
(wheelhouse + image artifacts attached; wheelhouse verified on a field
Pi via `eigsep-field sync-image`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)