### PR TITLE
release: pin Software-tab links to eigsep-field v2026.7.2

### DIFF
--- a/docs/_data/eigsep_field.yml
+++ b/docs/_data/eigsep_field.yml
@@ -3,5 +3,5 @@
 # new release tag (e.g. v2026.5.0). Between releases, tracking main is
 # acceptable because eigsep-field's docs-drift CI keeps interface docs
 # honest on every commit.
-tag: v2026.7.1
+tag: v2026.7.2
 repo_url: https://github.com/EIGSEP/eigsep-field


### PR DESCRIPTION
Retargets every outbound /software/ link at the v2026.7.2 release tag (final cut before the July 2026 field deployment; eigsep_observing 2.14.0 + picohost 4.5.0 + eigsep_redis 2.3.2, pico UF2 v4.5.0). Merge after EIGSEP/eigsep-field#56 is tagged so the links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)